### PR TITLE
Fix issue with detail links not working in Areas example.

### DIFF
--- a/src/WithAreas/Areas/Ninjas/Views/Home/Index.cshtml
+++ b/src/WithAreas/Areas/Ninjas/Views/Home/Index.cshtml
@@ -10,7 +10,7 @@
 <ul>
     @foreach (var item in Model)
     {
-        <li><a asp-controller="@ViewBag.ItemNames" asp-action="Details" asp-route-id="@item.Id">@item</a></li>
+        <li><a asp-action="Details" asp-route-id="@item.Id">@item</a></li>
     }
 </ul>
 <a asp-area="@ViewBag.ItemNames" asp-controller="Home" asp-action="Add">Add @ViewBag.ItemName</a>

--- a/src/WithAreas/Areas/Pirates/Views/Home/Index.cshtml
+++ b/src/WithAreas/Areas/Pirates/Views/Home/Index.cshtml
@@ -10,7 +10,7 @@
 <ul>
     @foreach (var item in Model)
     {
-        <li><a asp-controller="@ViewBag.ItemNames" asp-action="Details" asp-route-id="@item.Id">@item</a></li>
+        <li><a asp-action="Details" asp-route-id="@item.Id">@item</a></li>
     }
 </ul>
 <a asp-area="@ViewBag.ItemNames" asp-controller="Home" asp-action="Add">Add @ViewBag.ItemName</a>

--- a/src/WithAreas/Areas/Plants/Views/Home/Index.cshtml
+++ b/src/WithAreas/Areas/Plants/Views/Home/Index.cshtml
@@ -10,7 +10,7 @@
 <ul>
     @foreach (var item in Model)
     {
-        <li><a asp-controller="@ViewBag.ItemNames" asp-action="Details" asp-route-id="@item.Id">@item</a></li>
+        <li><a asp-action="Details" asp-route-id="@item.Id">@item</a></li>
     }
 </ul>
 <a asp-area="@ViewBag.ItemNames" asp-controller="Home" asp-action="Add">Add @ViewBag.ItemName</a>

--- a/src/WithAreas/Areas/Zombies/Views/Home/Index.cshtml
+++ b/src/WithAreas/Areas/Zombies/Views/Home/Index.cshtml
@@ -10,7 +10,7 @@
 <ul>
     @foreach (var item in Model)
     {
-        <li><a asp-controller="@ViewBag.ItemNames" asp-action="Details" asp-route-id="@item.Id">@item</a></li>
+        <li><a asp-action="Details" asp-route-id="@item.Id">@item</a></li>
     }
 </ul>
 <a asp-area="@ViewBag.ItemNames" asp-controller="Home" asp-action="Add">Add @ViewBag.ItemName</a>


### PR DESCRIPTION
Hi Steve,

Thank you very much for writing the article on ASP.NET folder organization and for putting together these examples!  They are very helpful and I really like the feature folder approach!

While trying out the code from your article I noticed that the detail links weren't working in the Area example.  It's because they still refer to the name of the controller as @ViewBag.ItemNames.  The problem is that in the areas example the controllers are all named Home.  

This issue can be fixed by changing the asp-controller attribute to "Home" for each of the link references or simply removing the asp-controller attribute.  The easiest thing to do is just to remove it, so that's what I've done in this PR.

Thank you again! 

David